### PR TITLE
feat: custom extension support simply pass in code

### DIFF
--- a/jinja2_test.go
+++ b/jinja2_test.go
@@ -125,6 +125,21 @@ def multiply(a, b):
 `))
 	assert.NoError(t, err)
 	assert.Equal(t, "test - 6", s)
+
+	s, err = j2.RenderString("test - {{ test_var1 | minus(-2) }}", WithExtension(`
+from jinja2.ext import Extension
+
+class DemoExtension(Extension):
+    def __init__(self, environment):
+        super().__init__(environment)
+        environment.filters['minus'] = self.minus
+        
+    @staticmethod
+    def minus(a, b):
+        return int(a) - int(b)
+`))
+	assert.NoError(t, err)
+	assert.Equal(t, "test - 3", s)
 }
 
 type testStruct struct {

--- a/opts.go
+++ b/opts.go
@@ -108,6 +108,10 @@ func WithFilter(name string, code string) Jinja2Opt {
 	}
 }
 
+// WithExtension adds a custom extension to the engine
+//
+// You can pass in an import path to an extension (for using some built-in extension, e.g. `jinja2.ext.debug`)
+// Or you can pass in the code of an extension (there must be exactly one class inherited from `jinja2.ext.Extension`)
 func WithExtension(e string) Jinja2Opt {
 	return func(o *jinja2Options) {
 		o.Extensions = append(o.Extensions, e)


### PR DESCRIPTION
The extension is a good feature. But now we can only use some "built-in" extension.

In this PR, I extend the semantics for the `Extensions` config so that users can also write code directly to use custom extensions.